### PR TITLE
Scope concurrency group to prevent cross-run blocking

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -20,8 +20,8 @@ permissions:
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  group: "pages-${{ github.ref }}"
+  cancel-in-progress: true
 
 jobs:
   # Build job


### PR DESCRIPTION
## Summary
- The workflow used a static concurrency group `"pages"`, which meant all runs (pushes to main, PRs, manual dispatches) shared a single queue with `cancel-in-progress: false`
- This caused PR check runs to stall indefinitely when a prior push-to-main run got stuck (e.g. run #215's deploy job was queued for 9 days, blocking run #216)
- Scoping the group to `pages-${{ github.ref }}` gives each branch its own concurrency lane, and `cancel-in-progress: true` ensures stale runs on the same branch are cancelled

## Test plan
- [ ] Verify this PR's own workflow run starts without getting stuck
- [ ] Confirm a push to `main` still triggers build + deploy without interference from open PR runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)